### PR TITLE
chore: Update gradle.properties for support latest ide version

### DIFF
--- a/.github/workflows/build_develop.yml
+++ b/.github/workflows/build_develop.yml
@@ -83,7 +83,7 @@ jobs:
       # Collect Tests Result of failed tests
       - name: Collect Tests Result
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tests-result
           path: ${{ github.workspace }}/build/reports/tests

--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -83,7 +83,7 @@ jobs:
       # Collect Tests Result of failed tests
       - name: Collect Tests Result
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tests-result
           path: ${{ github.workspace }}/build/reports/tests
@@ -108,7 +108,7 @@ jobs:
       # Collect Plugin Verifier Result
       - name: Collect Plugin Verifier Result
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pluginVerifier-result
           path: ${{ github.workspace }}/build/reports/pluginVerifier
@@ -130,7 +130,7 @@ jobs:
 
       # Store already-built plugin as an artifact for downloading
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.artifact.outputs.filename }}
           path: ./build/distributions/content/*/*

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion=2.0.2
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 232
-pluginUntilBuild = 243.*
+pluginUntilBuild = 251.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC


### PR DESCRIPTION
This update fixes a compatibility issue in latest ide version.

## Changes
- Expanded the plugin's compatible IDE build versions from `243.*` to `251.*`.